### PR TITLE
Use ID to Identify & Hide Contents List

### DIFF
--- a/src/mantid_sphinx_theme/static/css/style.css
+++ b/src/mantid_sphinx_theme/static/css/style.css
@@ -33,7 +33,6 @@ html[data-theme="dark"] {
 /** Hide contents elements while they can be removed from the sphinx source
  * The sidebars no give the same content.
 **/
-.contents {
+#contents {
   display: none;
-  visibility: hidden;
 }


### PR DESCRIPTION
Grabbing the contents by ID instead of by class seems to stop the large gap that we were seeing where the contents used to be in the sphinx source.

The `visibility` tag is also no-longer needed as the entire element including its box is no longer displayed.

I think the source of the bug is that the `pydata-sphinx-theme` already makes changes to the contents class and the style in here isn't overriding them. Which is maybe a larger-scale config issue. 

## To test
1. I tested this by using the Firefox "Style Editor" to change `style.css` until it looked right. If there's a better way to test this out I'd be interested to hear it. 